### PR TITLE
Fix CAM retrieval

### DIFF
--- a/Script_1/Script_1.py
+++ b/Script_1/Script_1.py
@@ -25,7 +25,14 @@ def run(context):
             ui.messageBox(f'Material: {material}')
 
         # --- Get CAM Estimated Times ---
-        cam_product = adsk.cam.CAM.cast(app.activeProduct)
+        # Access the CAM product from the active document. This works even if
+        # the Design workspace is active because `activeProduct` will then be a
+        # `Design` instance. Using `itemByProductType` ensures we can obtain the
+        # CAM product regardless of the currently active workspace.
+        cam_product = app.activeDocument.products.itemByProductType(
+            adsk.cam.CAM.classType())
+        cam_product = adsk.cam.CAM.cast(cam_product)
+
         if not cam_product:
             ui.messageBox("No CAM product found.")
             return


### PR DESCRIPTION
## Summary
- obtain the CAM product from the active document instead of the active product

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a857236088327b8cc31b9062f5268